### PR TITLE
fix EUROCRYPT 18 deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -66,7 +66,7 @@
   description: European Cryptology Conference
   year: 2018
   link: https://eurocrypt.iacr.org/2018/
-  deadline: "2017-09-19 23:59"
+  deadline: "2017-09-19 21:59"
   timezone: Etc/UTC
   date: Apr 29 - May 3
   place: Tel Aviv, Israel


### PR DESCRIPTION
This deadline is taken from the submission server (https://secure.iacr.org/websubrev/ec2018/submit/).