### PR TITLE
Update IEEE S&P year to 2018

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,6 +1,6 @@
 ---
 - name: S&P (Oakland)
-  year: 2019
+  year: 2018
   description: IEEE Symposium on Security and Privacy
   link: https://www.ieee-security.org/TC/SP2018/
   deadline: "%y-%m-01 15:00"


### PR DESCRIPTION
As I understand the [website](https://www.ieee-security.org/TC/SP2018/), the next S&P is in 2018, and if you submit until the 1st of december, you can still be part of that conference. This PR thus dates S&P for 2018 - feel free to correct me and close this issue if I misunderstood.