### PR TITLE
Add CCS deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -4,7 +4,7 @@
   year: 2018
   link: https://www.sigsac.org/ccs/CCS2018/
   deadline: "2018-05-08 20:59"
-  timezone: Etc/GMT-7
+  timezone: Etc/GMT+7
   date: "Oct 15 - Oct 19"
   place: Toronto, Canada
   tags: [SEC, PRIV]

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,14 @@
 ---
+- name: CCS
+  description: ACM Conference on Computer and Communications Security
+  year: 2018
+  link: https://www.sigsac.org/ccs/CCS2018/
+  deadline: "2018-05-08 20:59"
+  timezone: Etc/GMT+7
+  date: "Oct 15 - Oct 19"
+  place: Toronto, Canada
+  tags: [SEC, PRIV]
+
 - name: S&P (Oakland)
   year: 2018
   description: IEEE Symposium on Security and Privacy

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -4,7 +4,7 @@
   year: 2018
   link: https://www.sigsac.org/ccs/CCS2018/
   deadline: "2018-05-08 20:59"
-  timezone: Etc/GMT+7
+  timezone: Etc/GMT-7
   date: "Oct 15 - Oct 19"
   place: Toronto, Canada
   tags: [SEC, PRIV]


### PR DESCRIPTION
See CFP here: https://www.sigsac.org/ccs/CCS2018/papers.html.

As far as I know, the PDT / UTC-7 stated in the CFP should be equivalent to GMT-7, which (according to the readme) should be inverted to GMT+7. Timezones are weird, so please double-check this.