### PR TITLE
Add EuroS&P

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -4,7 +4,7 @@
   year: 2019
   link: https://www.ieee-security.org/TC/EuroSP2019/
   deadline: "2018-11-13 23:59"
-  comment: Abstract Registration until 2018-10-15
+  comment: Voluntary Abstract Registration until 2018-10-15
   date: "June 17 - June 19"
   place: Stockholm, Sweden
   tags: [SEC, PRIV]

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,14 @@
 ---
+- name: EuroS&P
+  description: IEEE European Symposium on Security and Privacy
+  year: 2019
+  link: https://www.ieee-security.org/TC/EuroSP2019/
+  deadline: "2018-11-13 23:59"
+  comment: Abstract Registration until 2018-10-15
+  date: "June 17 - June 19"
+  place: Stockholm, Sweden
+  tags: [SEC, PRIV]
+  
 - name: CT-RSA
   description: RSA Conference Cryptographers’ Track
   year: 2019


### PR DESCRIPTION
See [CFP](https://www.ieee-security.org/TC/EuroSP2019/cfp.php).

Standard caveats apply: I have no idea if I got the timezone right. Plus, there is an abstract registration deadline on October 15th, with the final deadline almost a month later (November 13th). Not sure how to model this here, so I added the final deadline, with the abstract registration deadline as a comment (one could also consider a double-deadline similar to the quarterly PETS deadline syntax) - feel free to modify, as always.