### PR TITLE
Proposal: suggesting removal of non-security conferences accepting security work (comments?)

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -259,16 +259,6 @@
   place: San Juan, Puerto Rico, USA
   tags: [SEC]
 
-- name: IMC
-  description: Internet Measurement Conference
-  year: 2018
-  link: http://conferences.sigcomm.org/imc/2018
-  deadline: "2018-05-18 17:00"
-  timezone: America/Los_Angeles
-  date: October 31 – November 2
-  place: Boston, MA, USA
-  tags: SEC
-
 - name: DSN
   description: The International Conference on Dependable Systems and Networks
   year: 2019


### PR DESCRIPTION
As far as I understand, IMC is a conference on measurement, and they also accept security-related work. I would like to raise the discussion whether you'd like to have a long list of conferences that also accept security work (which nowadays is virtually everything), and IMC is probably the edgiest of edge cases...