### PR TITLE
WiSec 2020 extended paper submission deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -94,7 +94,7 @@
   description: ACM Conference on Security and Privacy in Wireless and Mobile Networks
   year: 2020
   link: https://wisec2020.ins.jku.at/
-  deadline: "2020-02-28 23:59"
+  deadline: "2020-03-13 23:59"
   date: July 8-10
   place: Linz, Austria
   tags: [SEC, PRIV]


### PR DESCRIPTION
Updated the submission deadline for ACM WiSec 2020 which has been extended to 2020-03-13 23:59 (AoE)