### PR TITLE
Add missing comments for rolling deadlines (S&P, NDSS)

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -5,6 +5,7 @@
   date: "May 23 – 27 2021"
   description: IEEE Symposium on Security and Privacy
   link: https://www.ieee-security.org/TC/SP2021/
+  comment: Rolling deadline every quarter
   deadline:
     - "2020-03-05 23:59"
     - "2020-06-04 23:59"
@@ -61,6 +62,7 @@
   description: ISOC Network and Distributed System Security Symposium
   year: 2021
   link: https://www.ndss-symposium.org/ndss-2021/
+  comment: 2 review cycles
   deadline:
     - "%y-04-30 23:59"
     - "%y-07-17 23:59"


### PR DESCRIPTION
These two conferences are missing the comments to flag the multiple deadlines. 