### PR TITLE
Fix CSF 2022 winter deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -224,7 +224,8 @@
   deadline:
     - "2021-05-14 23:59"
     - "2021-10-01 23:59"
-    - "2022-02-05 23:59"
+    - "2022-02-04 23:59"
+  timezone: Etc/UTC-12
   comment: 3 deadlines
   date: August 2022
   place: Haifa, Israel

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -225,7 +225,7 @@
     - "2021-05-14 23:59"
     - "2021-10-01 23:59"
     - "2022-02-04 23:59"
-  timezone: Etc/UTC-12
+  timezone: Etc/UTC+12
   comment: 3 deadlines
   date: August 2022
   place: Haifa, Israel

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -225,7 +225,6 @@
     - "2021-05-14 23:59"
     - "2021-10-01 23:59"
     - "2022-02-04 23:59"
-  timezone: Etc/UTC+12
   comment: 3 deadlines
   date: August 2022
   place: Haifa, Israel


### PR DESCRIPTION
Hi, I noticed that the winter deadline for CSF 2022 differs from the official website ([link](https://www.ieee-security.org/TC/CSF2022/cfp.html)):
```
Important Dates AoE (UTC-12h)
[...]
Winter cycle:
February 4th, 2022: paper submission deadline
April 8th, 2022: author notification
```
**Changes**:
- Fix date
- Add timezone (UTC+12 in the code)