### PR TITLE
Update request

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -259,22 +259,22 @@
 
 - name: ACSAC
   description: Annual Computer Security Applications Conference
-  year: 2020
-  link: https://www.acsac.org/2020/
-  deadline: "2020-06-12 23:59"
-  date: Dec 7-11
+  year: 2021
+  link: https://www.acsac.org/2021/
+  deadline: "2021-06-23 23:59"
+  date: Dec 6-10
   place: Austin, TX, USA
   tags: [SEC]
 
 - name: IMC
   description: Internet Measurement Conference
-  year: 2020
+  year: 2021
   link: https://conferences.sigcomm.org/imc/2020/
-  deadline: "2020-05-26 23:59"
+  deadline: "2021-05-26 23:59"
   comment: Title and abstract deadline on May 19th
   timezone: America/Los_Angeles
-  date: October 27-29
-  place: Pittsburgh, PA, USA
+  date: November 2-4
+  place: Virtual
   tags: SEC
 
 - name: DSN

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -31,16 +31,14 @@
 
 - name: CCS
   description: ACM Conference on Computer and Communications Security
-  year: 2019
-  link: https://www.sigsac.org/ccs/CCS2019/
-  deadline: "2018-05-08 23:59"
+  year: 2020
+  link: https://www.sigsac.org/ccs/CCS2020/
   deadline:
-    - "%y-02-05 23:59"
-    - "%y-05-15 23:59"
-    - "%y-09-15 23:59"
-  comment: Rolling deadline every 4 months
-  date: "November 11-15"
-  place: London, UK
+    - "%y-01-20 23:59"
+    - "%y-05-04 23:59"
+  comment: 2 review cycles
+  date: "November 9-13"
+  place: Orlando, FL, USA
   tags: [SEC, PRIV]
 
 - name: AsiaCCS
@@ -54,8 +52,8 @@
 
 - name: Usenix
   description: Usenix Security Symposium
-  year: 2019
-  link: https://www.usenix.org/conference/usenixsecurity19
+  year: 2020
+  link: https://www.usenix.org/conference/usenixsecurity20
   deadline:
     - "%y-08-23 19:59"
     - "%y-11-15 19:59"
@@ -63,8 +61,8 @@
     - "%y-05-15 19:59"
   comment: Rolling deadline every quarter
   timezone: America/New_York
-  date: "August 14-16"
-  place: Santa Clara, CA, USA
+  date: "August 12-14"
+  place: Boston, MA, USA
   tags: [SEC, PRIV]
 
 - name: NDSS
@@ -97,6 +95,15 @@
   place: Linz, Austria
   tags: [SEC, PRIV]
 
+- name: SOUPS
+  description: Usenix Symposium on Usable Security and Privacy
+  year: 2020
+  link: https://www.usenix.org/conference/soups2020
+  deadline: "2020-02-20 23:59"
+  comment: Collocated with Usenix Security
+  date: August 9–11
+  place: Boston, MA, USA
+  tags: [SEC, PRIV]
 
 # Privacy
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -372,6 +372,7 @@
   place: Online Event
   tags: [SEC, PRIV]  
 
+# Workshops
 - name: NSPW
   description: New Security Paradigms Workshop
   year: 2021
@@ -380,4 +381,14 @@
   timezone: Etc/GMT+11
   date: October 25-28
   place: New Hampshire, USA
+  tags: [SEC, PRIV]
+  
+- name: Cloud S&P
+  description: Workshop on Cloud Security and Privacy
+  year: 2022
+  link: https://cloudsp2022.encs.concordia.ca/
+  comment: Collocated with ANCS
+  deadline: "2022-03-21 23:59"
+  date: June 20-23
+  place: Rome, Italy
   tags: [SEC, PRIV]

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -75,8 +75,8 @@
   description: European Symposium on Research in Computer Security
   year: 2020
   link: http://esorics2020.sccs.surrey.ac.uk
-  deadline: "2020-04-03 23:59"
-  comment: Title and abstract deadline on April 3
+  deadline: "2020-04-24 23:59"
+  comment: Title and abstract deadline on April 17
   date: September 23-27
   place: Surrey, UK 
   tags: [SEC, PRIV]
@@ -239,21 +239,21 @@
 # Networks and systems, applications
 
 - name: RAID
-  description: International Symposium on Recent Advances in Intrusion Detection
-  year: 2019
-  link: https://www.raid-2019.org/
-  deadline: "2019-04-02 23:59"
-  date: September 23-25
-  place: Beijing, China
+  description: International Symposium on Research in Attacks, Intrusions and Defenses
+  year: 2020
+  link: https://www.raid2020.org/
+  deadline: "2020-04-07 23:59"
+  date: October 14-16
+  place: Donostia/San Sebastian, Spain
   tags: SEC
 
 - name: ACSAC
   description: Annual Computer Security Applications Conference
-  year: 2019
-  link: https://www.acsac.org/2019/
-  deadline: "2019-06-08 23:59"
-  date: Dec 9-13
-  place: San Juan, Puerto Rico, USA
+  year: 2020
+  link: https://www.acsac.org/2020/
+  deadline: "2019-06-12 23:59"
+  date: Dec 7-11
+  place: Austin, TX, USA
   tags: [SEC]
 
 - name: IMC

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -62,12 +62,12 @@
 
 - name: NDSS
   description: ISOC Network and Distributed System Security Symposium
-  year: 2020
-  link: https://www.ndss-symposium.org/ndss2020/
+  year: 2021
+  link: https://www.ndss-symposium.org/ndss-2021/
   deadline:
-    - "%y-06-14 23:59"
-    - "%y-09-13 23:59"
-  date: February 23-26
+    - "%y-04-30 23:59"
+    - "%y-07-17 23:59"
+  date: February 21-24
   place: San Diego, CA, USA
   tags: SEC
 
@@ -251,19 +251,20 @@
   description: Annual Computer Security Applications Conference
   year: 2020
   link: https://www.acsac.org/2020/
-  deadline: "2019-06-12 23:59"
+  deadline: "2020-06-12 23:59"
   date: Dec 7-11
   place: Austin, TX, USA
   tags: [SEC]
 
 - name: IMC
   description: Internet Measurement Conference
-  year: 2019
-  link: http://conferences.sigcomm.org/imc/2019
-  deadline: "2019-05-06 17:00"
+  year: 2020
+  link: https://conferences.sigcomm.org/imc/2020/
+  deadline: "2020-05-26 23:59"
+  comment: Title and abstract deadline on May 19th
   timezone: America/Los_Angeles
-  date: October 21-23
-  place: Amsterdam, The Netherlands
+  date: October 27-29
+  place: Pittsburgh, PA, USA
   tags: SEC
 
 - name: DSN

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -37,12 +37,15 @@
 
 - name: AsiaCCS
   description: ACM Asia Conference on Computer and Communications Security
-  year: 2020
-  link: https://asiaccs2020.cs.nthu.edu.tw/
-  deadline: "2019-12-10 23:59"
-  date: "June 1-5"
-  place: Taipei, Taiwan
+  year: 2021
+  link: https://asiaccs2021.comp.polyu.edu.hk
+  deadline:
+    - "2020-08-21 23:59"
+    - "2020-12-11 23:59"
+  date: "June 7- June 11"
+  place: Hong Kong, China
   tags: [SEC, PRIV]
+  timezone: "Etc/GMT+12"
 
 - name: Usenix
   description: Usenix Security Symposium

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,6 +1,6 @@
 ---
 # Security and Privacy
-- name: S&P (San Francisco)
+- name: S&P (Oakland)
   year: 2021
   date: "May 23 – 27 2021"
   description: IEEE Symposium on Security and Privacy
@@ -10,7 +10,6 @@
     - "2020-06-04 23:59"
     - "2020-09-03 23:59"
     - "2020-12-03 23:59"
-  timezone: Etc/GMT+7
   place: San Francisco, California, USA
   tags: [SEC, PRIV]
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,13 +1,17 @@
 ---
 # Security and Privacy
 - name: S&P (San Francisco)
-  year: 2020
-  date: "May 18 – 20 2020"
+  year: 2021
+  date: "May 23 – 27 2021"
   description: IEEE Symposium on Security and Privacy
-  link: https://www.ieee-security.org/TC/SP2020/index.html
-  deadline: "%y-%m-01 15:00"
+  link: https://www.ieee-security.org/TC/SP2021/
+  deadline:
+    - "2020-03-05 23:59"
+    - "2020-06-04 23:59"
+    - "2020-09-03 23:59"
+    - "2020-12-03 23:59"
   timezone: Etc/GMT+7
-  comment: Rolling deadline every month
+  place: San Francisco, California, USA
   tags: [SEC, PRIV]
 
 - name: SafeThings

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -12,8 +12,8 @@
     - "2021-12-02 23:59"
   place: San Francisco, California, USA
   tags: [SEC, PRIV]
-
- - name: ICICS
+  
+- name: ICICS
   year: 2022
   date: "Sept 05 – 08 2022"
   description: The 24th International Conference on Information and Communications Security

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -112,8 +112,8 @@
   place: Vancouver, Canada.
   tags: [SEC, PRIV]
 
-- name: FC 2021
-  description: Financial Cryptography and Data Security 2021
+- name: FC
+  description: Financial Cryptography and Data Security
   year: 2021
   link: https://fc21.ifca.ai/index.php
   deadline: "2020-09-17 23:59"

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -75,12 +75,13 @@
 
 - name: ESORICS
   description: European Symposium on Research in Computer Security
-  year: 2020
-  link: http://esorics2020.sccs.surrey.ac.uk
-  deadline: "2020-04-24 23:59"
-  comment: Title and abstract deadline on April 17
-  date: September 23-27
-  place: Surrey, UK
+  year: 2021
+  link: https://esorics2021.athene-center.de/call-for-papers.php
+  deadline: "2021-05-12 23:59"
+  timezone: Etc/GMT-1
+  comment: Title and abstract deadline on May 5
+  date: October 4-8
+  place: Darmstadt, Germany
   tags: [SEC, PRIV]
 
 - name: WiSec

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -48,16 +48,13 @@
 - name: Usenix
   description: Usenix Security Symposium
   year: 2020
-  link: https://www.usenix.org/conference/usenixsecurity20
   deadline:
-    - "%y-08-23 19:59"
-    - "%y-11-15 19:59"
-    - "%y-02-15 19:59"
-    - "%y-05-15 19:59"
-  comment: Rolling deadline every quarter
-  timezone: America/New_York
-  date: "August 12-14"
-  place: Boston, MA, USA
+    - "%y-06-11 11:59"
+    - "%y-10-15 11:59"
+    - "%y-02-04 11:59"
+  comment: Rolling deadline every four months.
+  date: "August 11-13"
+  place: Vancouver, BC, Canada.
   tags: [SEC, PRIV]
 
 - name: NDSS
@@ -78,7 +75,7 @@
   deadline: "2020-04-24 23:59"
   comment: Title and abstract deadline on April 17
   date: September 23-27
-  place: Surrey, UK 
+  place: Surrey, UK
   tags: [SEC, PRIV]
 
 - name: WiSec
@@ -313,4 +310,3 @@
   date: "June 24-26"
   place: Rotkreuz, Switzerland
   tags: [SEC, PRIV, CRYPTO]
-

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -5,11 +5,11 @@
   date: "May 22 – 26 2022"
   description: IEEE Symposium on Security and Privacy
   link: https://www.ieee-security.org/TC/SP2022/
-  comment: Rolling deadline 
+  comment: Three deadlines
   deadline:
-    - "%y-06-08 23:59"
-    - "%y-10-12 23:59"
-    - "%y-02-01 23:59"
+    - "2021-04-15 23:59"
+    - "2021-08-19 23:59"
+    - "2021-12-02 23:59"
   place: San Francisco, California, USA
   tags: [SEC, PRIV]
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -49,9 +49,9 @@
   year: 2021
   link: https://www.usenix.org/conference/usenixsecurity21
   deadline:
-    - "%y-06-11 11:59"
-    - "%y-10-15 11:59"
-    - "%y-02-04 11:59"
+    - "%y-06-11 23:59"
+    - "%y-10-15 23:59"
+    - "%y-02-04 23:59"
   comment: Rolling deadline every four months.
   date: "August 11-13"
   place: Vancouver, BC, Canada.

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -389,7 +389,7 @@
   description: Workshop on Cloud Security and Privacy
   year: 2022
   link: https://cloudsp2022.encs.concordia.ca/
-  comment: Collocated with ANCS
+  comment: Collocated with ACNS
   deadline: "2022-03-21 23:59"
   date: June 20-23
   place: Rome, Italy

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -85,7 +85,7 @@
   description: ACM Conference on Security and Privacy in Wireless and Mobile Networks
   year: 2020
   link: https://wisec2020.ins.jku.at/
-  deadline: "2020-02-28 23:59"
+  deadline: "2020-03-13 23:59"
   date: July 8-10
   place: Linz, Austria
   tags: [SEC, PRIV]

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -27,8 +27,8 @@
   year: 2021
   link: https://www.sigsac.org/ccs/CCS2021/
   deadline:
-    - "%y-01-20 23:59"
-    - "%y-05-06 23:59"
+    - "2021-01-20 23:59"
+    - "2021-05-06 23:59"
   comment: 2 review cycles
   date: "November 14-19"
   place: Seoul, South Korea
@@ -53,10 +53,9 @@
   link: https://www.usenix.org/conference/usenixsecurity21
   deadline:
     - "2020-06-18 23:59"
-    - "%y-06-11 23:59"
-    - "%y-10-15 23:59"
-    - "%y-02-04 23:59"
-  comment: Rolling deadline every four months.
+    - "2020-10-15 23:59"
+    - "2021-02-04 23:59"
+  comment: 3 review cycles
   date: "August 11-13"
   place: Vancouver, BC, Canada.
   tags: [SEC, PRIV]
@@ -66,8 +65,8 @@
   year: 2021
   link: https://www.ndss-symposium.org/ndss-2021/
   deadline:
-    - "%y-04-30 23:59"
-    - "%y-07-31 23:59"
+    - "2020-04-30 23:59"
+    - "2020-07-31 23:59"
   date: February 21-24
   place: San Diego, CA, USA
   tags: SEC
@@ -116,7 +115,7 @@
 
 - name: PETS
   description: Privacy Enhancing Technologies Symposium
-  year: 2020
+  year: 2021
   link: https://petsymposium.org
   deadline:
     - "%y-05-31 23:59"
@@ -125,8 +124,8 @@
     - "%y-02-28 23:59"
   comment: Rolling deadline every quarter
   timezone: Etc/GMT+11
-  date: July 14-18
-  place: Montréal, Canada
+  date: July 12-16
+  place: Virtual
   tags: PRIV
 
 # Crypto
@@ -191,16 +190,15 @@
 
 - name: CSF
   description: IEEE Computer Security Foundations Symposium
-  year: 2020
-  link: https://www.ieee-security.org/TC/CSF2020/
+  year: 2021
+  link: https://www.ieee-security.org/TC/CSF2021/
   deadline:
-    - "%y-02-07 23:59"
-    - "%y-04-17 23:59"
-    - "%y-10-04 23:59"
-    - "%y-12-13 23:59"
+    - "2020-05-08 23:59"
+    - "2020-10-02 23:59"
+    - "2021-02-08 23:59"
   comment: Rolling deadline every quarter
-  date: June 22-26
-  place: Boston, MA, USA
+  date: June 21-25
+  place: Dubrovnik, Croatia
   tags: [SEC, PRIV]
 
 - name: PKC
@@ -225,7 +223,7 @@
 
 - name: TCHES
   description: IACR Transactions on Cryptographic Hardware and Embedded Systems
-  year: 2019
+  year: 2021
   link: https://ches.iacr.org/
   deadline:
     - "%y-07-15 23:59"
@@ -233,8 +231,8 @@
     - "%y-01-15 23:59"
     - "%y-04-15 23:59"
   comment: Rolling deadline every quarter
-  date: August 25-28
-  place: Atlanta, US
+  date: September 12-15
+  place: Beijing, China
   tags: [SEC, CRYPTO]
 
 # Networks and systems, applications

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -46,7 +46,8 @@
 
 - name: Usenix
   description: Usenix Security Symposium
-  year: 2020
+  year: 2021
+  link: https://www.usenix.org/conference/usenixsecurity21
   deadline:
     - "%y-06-11 11:59"
     - "%y-10-15 11:59"

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -269,10 +269,9 @@
 - name: IMC
   description: Internet Measurement Conference
   year: 2021
-  link: https://conferences.sigcomm.org/imc/2020/
+  link: https://conferences.sigcomm.org/imc/2021/
   deadline: "2021-05-26 23:59"
   comment: Title and abstract deadline on May 19th
-  timezone: America/Los_Angeles
   date: November 2-4
   place: Virtual
   tags: SEC

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -102,12 +102,12 @@
 
 - name: WPES
   description: Workshop on Privacy in the Electronic Society
-  year: 2019
-  link: http://www.wpes.tech
-  deadline: "2019-07-15 23:59"
+  year: 2020
+  link: https://www.wpes.tech/2020/
+  deadline: "2020-07-23 23:59"
   comment: Collocated with ACM CCS
-  date: "November 11"
-  place: London, UK
+  date: "November 9"
+  place: Orlando, USA
   timezone: Etc/GMT+11
   tags: [PRIV]
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -180,17 +180,7 @@
   date: December 8-12
   place: Kobe, Japan
   tags: CRYPTO
-
-- name: FC
-  description: Financial Cryptography and Data Security
-  year: 2020
-  link: http://fc20.ifca.ai/
-  deadline: "2019-09-23 23:59"
-  timezone: Etc/GMT+11
-  date: "Feb 10 - 14"
-  place: Kota Kinabalu, Sabah, Malaysia
-  tags: CRYPTO
-
+  
 - name: AFT
   description: ACM Conference on Advances in Financial Technologies
   year: 2020
@@ -260,10 +250,10 @@
 
 - name: RAID
   description: International Symposium on Research in Attacks, Intrusions and Defenses
-  year: 2020
-  link: https://www.raid2020.org/
-  deadline: "2020-04-07 23:59"
-  date: October 14-16
+  year: 2021
+  link: https://www.raid2021.org
+  deadline: "2021-03-26 23:59"
+  date: October 6-8
   place: Donostia/San Sebastian, Spain
   tags: SEC
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -114,11 +114,11 @@
 
 - name: FC
   description: Financial Cryptography and Data Security
-  year: 2021
-  link: https://fc21.ifca.ai/index.php
-  deadline: "2020-09-17 23:59"
-  date: March 1-5
-  place: Virtual
+  year: 2022
+  link: https://fc22.ifca.ai/
+  deadline: "2021-09-09 23:59"
+  date: February 14-18
+  place: Grenada
   tags: [SEC, PRIV, CRYPTO]
 
 - name: NordSec

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -126,12 +126,12 @@
 
 - name: SOUPS
   description: Usenix Symposium on Usable Security and Privacy
-  year: 2021
-  link: https://www.usenix.org/conference/soups2021
-  deadline: "2021-02-25 23:59"
-  comment: Collocated with Usenix Security; Paper registration due Feb 18 AoE.
-  date: August 8–10
-  place: Vancouver, Canada.
+  year: 2022
+  link: https://www.usenix.org/conference/soups2022
+  deadline: "2022-02-17 23:59"
+  comment: Collocated with Usenix Security; Paper registration due Feb 11 AoE.
+  date: August 7–9
+  place: Boston, USA.
   tags: [SEC, PRIV]
 
 - name: FC

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -211,15 +211,15 @@
 
 - name: CSF
   description: IEEE Computer Security Foundations Symposium
-  year: 2021
-  link: https://www.ieee-security.org/TC/CSF2021/
+  year: 2022
+  link: https://www.ieee-security.org/TC/CSF2022
   deadline:
-    - "2020-05-08 23:59"
-    - "2020-10-02 23:59"
-    - "2021-02-08 23:59"
-  comment: Rolling deadline every quarter
-  date: June 21-25
-  place: Dubrovnik, Croatia
+    - "2021-05-14 23:59"
+    - "2021-10-01 23:59"
+    - "2022-02-05 23:59"
+  comment: 3 deadlines
+  date: August 2022
+  place: Haifa, Israel
   tags: [SEC, PRIV]
 
 - name: PKC

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -14,15 +14,6 @@
   place: San Francisco, California, USA
   tags: [SEC, PRIV]
 
-- name: SafeThings
-  year: 2019
-  description: IEEE Workshop on the Internet of Safe Things (co-located with Oakland)
-  link: https://www.ieee-security.org/TC/SPW2019/SafeThings/
-  deadline: "2019-01-23 23:59"
-  date: "May 20 - May 22 19"
-  place: San Francisco, California, USA
-  tags: [SEC, PRIV]
-
 - name: Euro S&P
   description: IEEE European Symposium on Security and Privacy
   year: 2020
@@ -130,7 +121,7 @@
     - "%y-05-31 23:59"
     - "%y-08-31 23:59"
     - "%y-11-30 23:59"
-    - "%y-02-29 23:59"
+    - "%y-02-28 23:59"
   comment: Rolling deadline every quarter
   timezone: Etc/GMT+11
   date: July 14-18
@@ -180,7 +171,7 @@
   tags: CRYPTO
 
 - name: AFT
-  description: ACM Comference on Advances in Financial Technologies
+  description: ACM Conference on Advances in Financial Technologies
   year: 2019
   link: https://aft.acm.org/
   deadline: "2019-05-24 23:59"
@@ -246,15 +237,6 @@
 
 # Networks and systems, applications
 
-- name: PerCom
-  description: IEEE International Conference on Pervasive Computing and Communication
-  year: 2020
-  link: http://www.percom.org/
-  deadline: "2019-09-20 23:59"
-  date: "March 23-27"
-  place: Austin, TX, USA
-  tags: [SEC, PRIV]
-
 - name: RAID
   description: International Symposium on Recent Advances in Intrusion Detection
   year: 2019
@@ -300,25 +282,6 @@
   date: June 22-25
   place: Rome, Italy
   tags: [CRYPTO, SEC]
-
-- name: eCrime
-  description: Symposium on Electronic Crime Research
-  year: 2019
-  link: https://apwg.org/apwg-events/ecrime2019/cfp
-  deadline: "2019-08-30 23:59"
-  date: November 13-15
-  place: Pittsburgh, PA, USA
-  tags: SEC
-
-- name: DIMVA
-  description: Conference on Detection of Intrusions and Malware & Vulnerability Assessment
-  year: 2019
-  link: https://www.dimva2019.org/
-  deadline: "2019-02-18 23:59"
-  timezone: Etc/UTC
-  date: June 19-20
-  place: Gothenburg, Sweden
-  tags: SEC
 
 - name: SecDev
   year: 2019

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -49,6 +49,7 @@
   year: 2021
   link: https://www.usenix.org/conference/usenixsecurity21
   deadline:
+    - "2020-06-18 23:59"
     - "%y-06-11 23:59"
     - "%y-10-15 23:59"
     - "%y-02-04 23:59"

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -94,12 +94,12 @@
 
 - name: SOUPS
   description: Usenix Symposium on Usable Security and Privacy
-  year: 2020
-  link: https://www.usenix.org/conference/soups2020
-  deadline: "2020-02-20 23:59"
-  comment: Collocated with Usenix Security
-  date: August 9–11
-  place: Boston, MA, USA
+  year: 2021
+  link: https://www.usenix.org/conference/soups2021
+  deadline: "2021-02-25 23:59"
+  comment: Collocated with Usenix Security; Paper registration due Feb 18 AoE.
+  date: August 8–10
+  place: Vancouver, Canada.
   tags: [SEC, PRIV]
 
 # Privacy

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -7,10 +7,10 @@
   link: https://www.ieee-security.org/TC/SP2021/
   comment: Rolling deadline every quarter
   deadline:
-    - "2020-03-05 23:59"
-    - "2020-06-04 23:59"
-    - "2020-09-03 23:59"
-    - "2020-12-03 23:59"
+    - "%y-03-05 23:59"
+    - "%y-06-04 23:59"
+    - "%y-09-03 23:59"
+    - "%y-12-03 23:59"
   place: San Francisco, California, USA
   tags: [SEC, PRIV]
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -36,16 +36,15 @@
 
 - name: AsiaCCS
   description: ACM Asia Conference on Computer and Communications Security
-  year: 2021
-  link: https://asiaccs2021.comp.polyu.edu.hk
+  year: 2022
+  link: https://asiaccs2022.conferenceservice.jp/
   deadline:
-    - "2020-08-21 23:59"
-    - "2020-12-11 23:59"
+    - "2021-07-30 23:59"
+    - "2021-11-19 23:59"
   comment: 2 review cycles
-  date: "June 7- June 11"
-  place: Hong Kong, China
+  date: "May 30 - June 3"
+  place: Nagasaki, Japan
   tags: [SEC, PRIV]
-  timezone: "Etc/GMT+12"
 
 - name: Usenix
   description: Usenix Security Symposium

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -192,10 +192,12 @@
   description: IEEE Computer Security Foundations Symposium
   year: 2020
   link: https://www.ieee-security.org/TC/CSF2020/
-  deadline: "2019-09-16 23:59"
   deadline:
     - "%y-02-07 23:59"
-  comment: Rolling deadline three times per year
+    - "%y-04-17 23:59"
+    - "%y-10-04 23:59"
+    - "%y-12-13 23:59"
+  comment: Rolling deadline every quarter
   date: June 22-26
   place: Boston, MA, USA
   tags: [SEC, PRIV]
@@ -229,7 +231,7 @@
     - "%y-10-15 23:59"
     - "%y-01-15 23:59"
     - "%y-04-15 23:59"
-  comment: Rolling deadline every 3 months
+  comment: Rolling deadline every quarter
   date: August 25-28
   place: Atlanta, US
   tags: [SEC, CRYPTO]

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,16 +1,15 @@
 ---
 # Security and Privacy
 - name: S&P (Oakland)
-  year: 2021
-  date: "May 23 – 27 2021"
+  year: 2022
+  date: "May 22 – 26 2022"
   description: IEEE Symposium on Security and Privacy
-  link: https://www.ieee-security.org/TC/SP2021/
-  comment: Rolling deadline every quarter
+  link: https://www.ieee-security.org/TC/SP2022/
+  comment: Rolling deadline 
   deadline:
-    - "%y-03-05 23:59"
-    - "%y-06-04 23:59"
-    - "%y-09-03 23:59"
-    - "%y-12-03 23:59"
+    - "%y-06-08 23:59"
+    - "%y-10-12 23:59"
+    - "%y-02-01 23:59"
   place: San Francisco, California, USA
   tags: [SEC, PRIV]
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -315,10 +315,12 @@
 
 - name: ACNS
   description: International Conference on Applied Cryptography and Network Security
-  year: 2020
-  link: https://sites.google.com/di.uniroma1.it/ACNS2020
-  deadline: "2020-01-20 23:59"
-  date: June 22-25
+  year: 2022
+  link: https://sites.google.com/di.uniroma1.it/acns2022
+  deadline: 
+    - "2021-09-03 23:59"
+    - "2022-01-14 23:59"
+  date: June 20-23
   place: Rome, Italy
   tags: [CRYPTO, SEC]
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -64,7 +64,7 @@
   link: https://www.ndss-symposium.org/ndss-2021/
   deadline:
     - "%y-04-30 23:59"
-    - "%y-07-17 23:59"
+    - "%y-07-31 23:59"
   date: February 21-24
   place: San Diego, CA, USA
   tags: SEC

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -73,12 +73,12 @@
 
 - name: ESORICS
   description: European Symposium on Research in Computer Security
-  year: 2019
-  link: https://esorics2019.uni.lu/
-  deadline: "2019-04-29 23:59"
-  timezone: Etc/UTC-11
+  year: 2020
+  link: http://esorics2020.sccs.surrey.ac.uk
+  deadline: "2020-04-03 23:59"
+  comment: Title and abstract deadline on April 3
   date: September 23-27
-  place: Luxembourg
+  place: Surrey, UK 
   tags: [SEC, PRIV]
 
 - name: WiSec
@@ -132,11 +132,11 @@
 
 - name: Crypto
   description: International Cryptology Conference
-  year: 2019
-  link: https://crypto.iacr.org/2019/
-  deadline: "2019-02-13 16:00"
+  year: 2020
+  link: https://crypto.iacr.org/2020
+  deadline: "2020-02-11 16:00"
   timezone: Etc/GMT+5
-  date: August
+  date: August 16-20
   place: Santa Barbara, CA, USA
   tags: CRYPTO
 
@@ -172,21 +172,20 @@
 
 - name: AFT
   description: ACM Conference on Advances in Financial Technologies
-  year: 2019
+  year: 2020
   link: https://aft.acm.org/
-  deadline: "2019-05-24 23:59"
+  deadline: "2020-06-04 23:59"
   date: "Oct 21 – 23"
-  place: Zurich, Switzerland
+  place: New York City, USA
   tags: [SEC, PRIV, CRYPTO]
 
 - name: TCC
   description: Theory of Cryptography Conference
-  year: 2019
+  year: 2020
   link: https://www.iacr.org/workshops/tcc
-  deadline: "2019-05-29 22:59"
-  timezone: Etc/UTC
-  date: December 1-5
-  place: Nuremberg, Germany
+  deadline: TBA
+  date: November
+  place: Durham, NC, USA
   tags: CRYPTO
 
 - name: CSF
@@ -284,29 +283,31 @@
   tags: [CRYPTO, SEC]
 
 - name: SecDev
-  year: 2019
+  year: 2020
   description: IEEE Secure Development Conference
   link: https://secdev.ieee.org/
-  deadline: "2019-04-22 23:59"
-  date: "September 25-27"
-  place: McLean, VA, USA
+  deadline: "2020-05-25 23:59"
+  date: "September 18-30"
+  place: Atlanta, GA, USA
   tags: [SEC, PRIV]
 
 - name: ISC
   description: The Information Security Conference
-  year: 2019
-  link: https://isc2019.cs.stonybrook.edu/
-  deadline: "2019-04-05 23:59"
+  year: 2020
+  link: https://isc2020.petra.ac.id/
+  deadline: "2020-05-28 23:59"
+  timezone: Etc/UTC
   date: "September 16-18"
   place: New York, USA
   tags: [SEC, INFOR]
 
 - name: CVCBT
   description: CryptoValley Conference on Blockchain Technologies
-  year: 2019
+  year: 2020
   link: http://www.cryptovalleyconference.com/technology-call-for-papers
-  deadline: "2019-04-15 23:59"
+  deadline: "2020-04-03 16:00"
   timezone: Europe/Zurich
   date: "June 24-26"
-  place: Zug, Switzerland
+  place: Rotkreuz, Switzerland
   tags: [SEC, PRIV, CRYPTO]
+

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -91,6 +91,19 @@
   date: September 26-30
   place: Copenhagen, Denmark
   tags: [SEC, PRIV]
+  
+- name: CSF
+  description: IEEE Computer Security Foundations Symposium
+  year: 2022
+  link: https://www.ieee-security.org/TC/CSF2022
+  deadline:
+    - "2021-05-14 23:59"
+    - "2021-10-01 23:59"
+    - "2022-02-04 23:59"
+  comment: 3 deadlines
+  date: August 2022
+  place: Haifa, Israel
+  tags: [SEC, PRIV]
     
 - name: CANS
   description: International Conference on Cryptology and Network Security
@@ -218,19 +231,6 @@
   place: Durham, NC, USA
   tags: CRYPTO
 
-- name: CSF
-  description: IEEE Computer Security Foundations Symposium
-  year: 2022
-  link: https://www.ieee-security.org/TC/CSF2022
-  deadline:
-    - "2021-05-14 23:59"
-    - "2021-10-01 23:59"
-    - "2022-02-04 23:59"
-  comment: 3 deadlines
-  date: August 2022
-  place: Haifa, Israel
-  tags: [SEC, PRIV]
-
 - name: PKC
   description: International Conference on Practice and Theory of Public Key Cryptography
   year: 2020
@@ -324,6 +324,8 @@
   date: June 20-23
   place: Rome, Italy
   tags: [CRYPTO, SEC]
+  
+# Others, less frequently updated
 
 - name: SecDev
   year: 2020

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -33,14 +33,14 @@
 
 - name: CCS
   description: ACM Conference on Computer and Communications Security
-  year: 2021
-  link: https://www.sigsac.org/ccs/CCS2021/
+  year: 2022
+  link: https://www.sigsac.org/ccs/CCS2022/
   deadline:
-    - "2021-01-20 23:59"
-    - "2021-05-06 23:59"
+    - "2022-01-14 23:59"
+    - "2022-05-02 23:59"
   comment: 2 review cycles
   date: "November 14-19"
-  place: Seoul, South Korea
+  place: Los Angeles, USA
   tags: [SEC, PRIV]
 
 - name: AsiaCCS

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -297,12 +297,12 @@
 
 - name: DSN
   description: The International Conference on Dependable Systems and Networks
-  year: 2021
-  link: http://dsn2021.ntu.edu.tw/
-  deadline: "2020-12-11 23:59"
-  comment: Title and abstract deadline on Dec 4th
-  date: June 21-24
-  place: Taipei, Taiwan
+  year: 2022
+  link: https://dsn2022.github.io/
+  deadline: "2021-12-10 23:59"
+  comment: Title and abstract deadline on Dec 3rd
+  date: June 27-30
+  place: Baltimore, MD, USA
   tags: SEC
 
 - name: ACNS

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -90,11 +90,11 @@
 
 - name: WiSec
   description: ACM Conference on Security and Privacy in Wireless and Mobile Networks
-  year: 2019
-  link: https://wisec19.fiu.edu
-  deadline: "2019-01-25 23:59"
-  date: May 15-17
-  place: Miami, Fl, USA
+  year: 2020
+  link: https://wisec2020.ins.jku.at/
+  deadline: "2020-02-28 23:59"
+  date: July 8-10
+  place: Linz, Austria
   tags: [SEC, PRIV]
 
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -86,7 +86,7 @@
 
 - name: WiSec
   description: ACM Conference on Security and Privacy in Wireless and Mobile Networks
-  year: 2020
+  year: 2021
   link: https://sites.nyuad.nyu.edu/wisec21/
   deadline: "2021-03-18 23:59"
   date: June 28 - July 1

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -275,9 +275,9 @@
 - name: DSN
   description: The International Conference on Dependable Systems and Networks
   year: 2020
-  link: https://dsn.org/
+  link: https://dsn2020.webs.upv.es/
   deadline: "2019-12-03 23:59"
-  date: TBA
+  date: June 29 - July 2
   place: Valencia, Spain
   tags: SEC
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -184,8 +184,8 @@
   description: Theory of Cryptography Conference
   year: 2020
   link: https://www.iacr.org/workshops/tcc
-  deadline: TBA
-  date: November
+  deadline: "2020-05-26 23:59"
+  date: "November 16-19"
   place: Durham, NC, USA
   tags: CRYPTO
 

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
         {% endfor %}
       </div>
       <footer>
-        Maintained by @<a href="//twitter.com/{{ site.twitter_username }}">{{ site.twitter_username }}</a>.
+        Maintained by <a href="https://clementfung.github.io/">Clement Fung</a>. Created by <a href="//twitter.com/{{ site.twitter_username }}">Bogdan Kulynych</a>.
       </footer>
     </div>
 


### PR DESCRIPTION
Hi,
There are a few mistakes in our conference information, Cloud S&P 2022.
Please change ANCS to ACNS, and change the deadline from 22 March 2022 to 21 March 2022.
https://cloudsp2022.encs.concordia.ca/