### PR TITLE
Show all deadlines of multi-deadline conferences at once.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,15 @@ Fields marked with asterisk (\*) are required.
 The *deadline* field can contain:
 
 1. The simplest option: a date and time in ISO format. Example: `["2017-08-19 23:59"]` (Note that you need to wrap even a single deadline in a list).
-2. If a deadline is rolling, you can use a template date, just substitute the year with `%y`, or month with `%m`. Example: `["%y-%m-15 23:59"]` means there is a deadline on the 15th day of every month, every year. `"2017-%m-15"` means a deadline on 15th day of every month, but only in 2017, i.e. `"2018-01-15"` is not a part of this template.
-2. A list of (1) or (2). Example of two rolling deadlines, with one in the end of May every year, and the second in the end of February:
+2. If a deadline is rolling, you can use a template date, just substitute the
+   year with `%y` and the year before the conference with `%Y`. Example:
+   `["%y-01-15 23:59"]` means there is a deadline on the 15th January in the
+   same year as the conference.
+2. A list of (1) or (2). Example of two rolling deadlines, with one in the end
+   of October in the year prior to the conference year, and the second in the
+   end of February in the same year as the conference:
   ```
-  - "%y-05-31 23:59"
+  - "%Y-10-31 23:59"
   - "%y-02-28 23:59"
   ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Descriptions of the fields:
 | `year`\*      | Year the conference is happening                            |
 | `description` | Description, or long name                                   |
 | `link`\*      | URL to the conference home page                             |
-| `deadline`\*  | Deadline, or list of deadlines. (Gory details below)        |
+| `deadline`\*  | A list of deadlines. (Gory details below)                   |
 | `timezone`    | Timezone in [tz][1] format. By default is UTC-12 ([AoE][2]) |
 | `date`        | When the conference is happening                            |
 | `place`       | Where the conference is happening                           |
@@ -44,8 +44,8 @@ Fields marked with asterisk (\*) are required.
 
 The *deadline* field can contain:
 
-1. The simplest option: a date and time in ISO format. Example: `"2017-08-19 23:59"`.
-2. If a deadline is rolling, you can use a template date, just substitute the year with `%y`, or month with `%m`. Example: `"%y-%m-15 23:59"` means there is a deadline on the 15th day of every month, every year. `"2017-%m-15"` means a deadline on 15th day of every month, but only in 2017, i.e. `"2018-01-15"` is not a part of this template.
+1. The simplest option: a date and time in ISO format. Example: `["2017-08-19 23:59"]` (Note that you need to wrap even a single deadline in a list).
+2. If a deadline is rolling, you can use a template date, just substitute the year with `%y`, or month with `%m`. Example: `["%y-%m-15 23:59"]` means there is a deadline on the 15th day of every month, every year. `"2017-%m-15"` means a deadline on 15th day of every month, but only in 2017, i.e. `"2018-01-15"` is not a part of this template.
 2. A list of (1) or (2). Example of two rolling deadlines, with one in the end of May every year, and the second in the end of February:
   ```
   - "%y-05-31 23:59"

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -5,7 +5,6 @@
   date: "May 22 – 26 2023"
   description: IEEE Symposium on Security and Privacy
   link: https://www.ieee-security.org/TC/SP2023
-  comment: Three deadlines
   deadline:
     - "2022-04-01 23:59"
     - "2022-08-19 23:59"
@@ -18,7 +17,7 @@
   date: "Sept 05 – 08 2022"
   description: The 24th International Conference on Information and Communications Security
   link: https://icics2022.cyber.kent.ac.uk/index.php
-  deadline: "2022-03-21 23:59"
+  deadline: ["2022-03-21 23:59"]
   place: University of Kent, Canterbury, UK
   tags: [SEC, PRIV]
 
@@ -26,7 +25,7 @@
   description: IEEE European Symposium on Security and Privacy
   year: 2022
   link: https://www.ieee-security.org/TC/EuroSP2022/
-  deadline: "2021-09-22 23:59"
+  deadline: ["2021-09-22 23:59"]
   date: "June 6 - 10"
   place: Genova, Italy
   tags: [SEC, PRIV]
@@ -38,7 +37,6 @@
   deadline:
     - "2022-01-14 23:59"
     - "2022-05-02 23:59"
-  comment: 2 review cycles
   date: "November 14-19"
   place: Los Angeles, USA
   tags: [SEC, PRIV]
@@ -50,7 +48,6 @@
   deadline:
     - "2021-07-30 23:59"
     - "2021-11-19 23:59"
-  comment: 2 review cycles
   date: "May 30 - June 3"
   place: Nagasaki, Japan
   tags: [SEC, PRIV]
@@ -63,7 +60,6 @@
     - "2021-06-08 23:59"
     - "2021-10-12 23:59"
     - "2022-02-01 23:59"
-  comment: 3 review cycles
   date: "August 10-12"
   place: Boston, MA, USA.
   tags: [SEC, PRIV]
@@ -72,7 +68,6 @@
   description: ISOC Network and Distributed System Security Symposium
   year: 2022
   link: https://www.ndss-symposium.org/ndss2022/
-  comment: 2 review cycles
   deadline:
     - "2021-05-21 23:59"
     - "2021-07-23 23:59"
@@ -100,7 +95,6 @@
     - "2021-05-14 23:59"
     - "2021-10-01 23:59"
     - "2022-02-04 23:59"
-  comment: 3 deadlines
   date: August 2022
   place: Haifa, Israel
   tags: [SEC, PRIV]
@@ -109,7 +103,7 @@
   description: International Conference on Cryptology and Network Security
   year: 2021
   link: https://cans2021.at/call-for-papers/
-  deadline: "2021-06-17 23:59"
+  deadline: ["2021-06-17 23:59"]
   timezone: Etc/UTC
   date: December 13-15
   place: Vienna, Austria
@@ -119,7 +113,7 @@
   description: ACM Conference on Security and Privacy in Wireless and Mobile Networks
   year: 2022
   link: https://wisec2022.cs.utsa.edu/
-  deadline: "2022-02-02 23:59"
+  deadline: ["2022-02-02 23:59"]
   date: May 16 - May 19
   place: San Antonio, Texas, USA
   tags: [SEC, PRIV]
@@ -128,7 +122,7 @@
   description: Usenix Symposium on Usable Security and Privacy
   year: 2022
   link: https://www.usenix.org/conference/soups2022
-  deadline: "2022-02-17 23:59"
+  deadline: ["2022-02-17 23:59"]
   comment: Collocated with Usenix Security; Paper registration due Feb 11 AoE.
   date: August 7–9
   place: Boston, USA.
@@ -138,7 +132,7 @@
   description: Financial Cryptography and Data Security
   year: 2022
   link: https://fc22.ifca.ai/
-  deadline: "2021-09-09 23:59"
+  deadline: ["2021-09-09 23:59"]
   date: February 14-18
   place: Grenada
   tags: [SEC, PRIV, CRYPTO]
@@ -147,7 +141,7 @@
   description: Nordic Conference on Secure IT Systems
   year: 2021
   link: https://events.tuni.fi/nordsec2021/
-  deadline: "2021-08-23 23:59"
+  deadline: ["2021-08-23 23:59"]
   timezone: Europe/Helsinki
   date: November 29-30
   place: Virtual
@@ -159,7 +153,7 @@
   description: Workshop on Privacy in the Electronic Society
   year: 2020
   link: https://www.wpes.tech/2020/
-  deadline: "2020-07-23 23:59"
+  deadline: ["2020-07-23 23:59"]
   comment: Collocated with ACM CCS
   date: "November 9"
   place: Orlando, USA
@@ -187,7 +181,7 @@
   description: International Cryptology Conference
   year: 2022
   link: https://crypto.iacr.org/2022/
-  deadline: "2022-02-16 11:59"
+  deadline: ["2022-02-16 11:59"]
   date: August 13-18
   place: Santa Barbara, CA, USA
   tags: CRYPTO
@@ -196,7 +190,7 @@
   description: European Cryptology Conference
   year: 2020
   link: https://eurocrypt.iacr.org/2020/
-  deadline: "2019-09-26 11:59"
+  deadline: ["2019-09-26 11:59"]
   timezone: Europe/Zurich
   date: May 10 - May 14
   place: Zagreb, Croatia
@@ -206,7 +200,7 @@
   description: International Conference on the Theory and Application of Cryptology and Information Security
   year: 2019
   link: https://asiacrypt.iacr.org/2019
-  deadline: "2019-05-14 05:00"
+  deadline: ["2019-05-14 05:00"]
   timezone: Etc/UTC
   date: December 8-12
   place: Kobe, Japan
@@ -216,7 +210,7 @@
   description: ACM Conference on Advances in Financial Technologies
   year: 2020
   link: https://aft.acm.org/
-  deadline: "2020-06-04 23:59"
+  deadline: ["2020-06-04 23:59"]
   date: "Oct 21 – 23"
   place: New York City, USA
   tags: [SEC, PRIV, CRYPTO]
@@ -225,7 +219,7 @@
   description: Theory of Cryptography Conference
   year: 2020
   link: https://www.iacr.org/workshops/tcc
-  deadline: "2020-05-26 23:59"
+  deadline: ["2020-05-26 23:59"]
   date: "November 16-19"
   place: Durham, NC, USA
   tags: CRYPTO
@@ -234,7 +228,7 @@
   description: International Conference on Practice and Theory of Public Key Cryptography
   year: 2020
   link: https://pkc.iacr.org/2020/
-  deadline: "2019-11-02 09:59"
+  deadline: ["2019-11-02 09:59"]
   timezone: Etc/UTC
   date: May 4-7
   place: Edinburgh, Scotland, UK
@@ -244,7 +238,7 @@
   description: RSA Conference Cryptographers’ Track
   year: 2020
   link: https://sites.google.com/view/ctrsa2020/home
-  deadline: "2019-09-20 23:59"
+  deadline: ["2019-09-20 23:59"]
   timezone: Etc/GMT+5
   date: February 24-28
   place: San Francisco, CA, USA
@@ -268,7 +262,7 @@
   description: Conference on Selected Areas in Cryptography
   year: 2021
   link: https://www.sac2021.ca/
-  deadline: "2021-07-12 23:59"
+  deadline: ["2021-07-12 23:59"]
   date: September 29 - October 1
   place: Online Event
   tags: [CRYPTO, PRIV]
@@ -279,7 +273,7 @@
   description: International Symposium on Research in Attacks, Intrusions and Defenses
   year: 2021
   link: https://www.raid2021.org
-  deadline: "2021-03-26 23:59"
+  deadline: ["2021-03-26 23:59"]
   date: October 6-8
   place: Donostia/San Sebastian, Spain
   tags: SEC
@@ -288,7 +282,7 @@
   description: Annual Computer Security Applications Conference
   year: 2021
   link: https://www.acsac.org/2021/
-  deadline: "2021-06-23 23:59"
+  deadline: ["2021-06-23 23:59"]
   date: Dec 6-10
   place: Austin, TX, USA
   tags: [SEC]
@@ -297,7 +291,7 @@
   description: Internet Measurement Conference
   year: 2021
   link: https://conferences.sigcomm.org/imc/2021/
-  deadline: "2021-05-26 23:59"
+  deadline: ["2021-05-26 23:59"]
   comment: Title and abstract deadline on May 19th
   date: November 2-4
   place: Virtual
@@ -307,7 +301,7 @@
   description: The International Conference on Dependable Systems and Networks
   year: 2022
   link: https://dsn2022.github.io/
-  deadline: "2021-12-10 23:59"
+  deadline: ["2021-12-10 23:59"]
   comment: Title and abstract deadline on Dec 3rd
   date: June 27-30
   place: Baltimore, MD, USA
@@ -330,7 +324,7 @@
   year: 2020
   description: IEEE Secure Development Conference
   link: https://secdev.ieee.org/
-  deadline: "2020-05-25 23:59"
+  deadline: ["2020-05-25 23:59"]
   date: "September 18-30"
   place: Atlanta, GA, USA
   tags: [SEC, PRIV]
@@ -339,7 +333,7 @@
   description: The Information Security Conference
   year: 2020
   link: https://isc2020.petra.ac.id/
-  deadline: "2020-05-28 23:59"
+  deadline: ["2020-05-28 23:59"]
   timezone: Etc/UTC
   date: "September 16-18"
   place: New York, USA
@@ -349,7 +343,7 @@
   description: CryptoValley Conference on Blockchain Technologies
   year: 2020
   link: http://www.cryptovalleyconference.com/technology-call-for-papers
-  deadline: "2020-04-03 16:00"
+  deadline: ["2020-04-03 16:00"]
   timezone: Europe/Zurich
   date: "June 24-26"
   place: Rotkreuz, Switzerland
@@ -359,7 +353,7 @@
   description: IEEE International Conference on Decentralized Applications and Infrastructures
   year: 2021
   link: https://ieeedapps.net/
-  deadline: "2021-04-27 23:59"
+  deadline: ["2021-04-27 23:59"]
   date: August 23-26
   place: Online Event
   tags: [SEC, PRIV]
@@ -368,7 +362,7 @@
   description: IEEE Security & Privacy on the Blockchain
   year: 2021
   link: https://ieeesb.org/
-  deadline: "2021-05-14 23:59"
+  deadline: ["2021-05-14 23:59"]
   date: September 7-11
   place: Online Event
   tags: [SEC, PRIV]  
@@ -378,7 +372,7 @@
   description: New Security Paradigms Workshop
   year: 2022
   link: https://www.nspw.org/2022/
-  deadline: "2022-05-22 23:59"
+  deadline: ["2022-05-22 23:59"]
   date: October 24-27
   place: New Hampshire, USA
   tags: [SEC, PRIV]
@@ -388,7 +382,7 @@
   year: 2022
   link: https://cloudsp2022.encs.concordia.ca/
   comment: Collocated with ACNS
-  deadline: "2022-03-21 23:59"
+  deadline: ["2022-03-21 23:59"]
   date: June 20-23
   place: Rome, Italy
   tags: [SEC, PRIV]

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,5 @@
 ---
+
 # Security and Privacy
 - name: S&P (Oakland)
   year: 2023
@@ -165,9 +166,9 @@
   year: 2022
   link: https://petsymposium.org
   deadline:
-    - "%y-05-31 23:59"
-    - "%y-08-31 23:59"
-    - "%y-11-30 23:59"
+    - "%Y-05-31 23:59"
+    - "%Y-08-31 23:59"
+    - "%Y-11-30 23:59"
     - "%y-02-28 23:59"
   comment: Rolling deadline every quarter
   timezone: Etc/GMT+11
@@ -246,11 +247,11 @@
 
 - name: TCHES
   description: IACR Transactions on Cryptographic Hardware and Embedded Systems
-  year: 2021
+  year: 2022
   link: https://ches.iacr.org/
   deadline:
-    - "%y-07-15 23:59"
-    - "%y-10-15 23:59"
+    - "%Y-07-15 23:59"
+    - "%Y-10-15 23:59"
     - "%y-01-15 23:59"
     - "%y-04-15 23:59"
   comment: Rolling deadline every quarter

--- a/index.html
+++ b/index.html
@@ -52,7 +52,12 @@
       </div>
       <div class="conf-container">
         {% for conf in site.data.conferences %}
-        <div id="{{ conf.name | append: conf.year | slugify }}" class="conf {% for tag in conf.tags %} {{tag}} {% endfor %}">
+        {% assign num_deadlines = conf.deadline.size %}
+        {% assign range_end = conf.deadline.size | minus: 1 %}
+        {% for i in (0..range_end) %}
+        {% assign deadline = conf.deadline[i] %}
+        {% assign conf_id = conf.name | append: conf.year | append: '-' | append: i | slugify %}
+        <div id="{{ conf_id }}" class="conf {% for tag in conf.tags %} {{tag}} {% endfor %}">
           <div class="row">
               <div class="col-xs-12 col-sm-6">
                 <h2><a href="{{conf.link}}">{{conf.name}} {{conf.year}}</a></h2>
@@ -64,8 +69,16 @@
               <div class="col-xs-12 col-sm-6">
                 <span class="timer"></span>
                 <div class="deadline">
-                  <div>Deadline:
-                    <span class="deadline-time"></span>
+                  <div>
+                      {% if num_deadlines >=2 %}
+                      {% if conf.comment %}<br />{% endif %}
+                      Deadline ({{ i | plus: 1 }} / {{ num_deadlines }}):
+                      {% else %}
+                      Deadline:
+                      {% endif %}
+                    <span class="deadline-time">
+                      {{ deadline }}
+                    </span>
                     <div class="meta">
                       {{ conf.comment }}
                     </div>
@@ -75,6 +88,7 @@
           </div>
           <hr>
         </div>
+        {% endfor %}
         {% endfor %}
       </div>
       <footer>

--- a/index.html
+++ b/index.html
@@ -71,7 +71,6 @@
                 <div class="deadline">
                   <div>
                       {% if num_deadlines >=2 %}
-                      {% if conf.comment %}<br />{% endif %}
                       Deadline ({{ i | plus: 1 }} / {{ num_deadlines }}):
                       {% else %}
                       Deadline:

--- a/index.html
+++ b/index.html
@@ -55,7 +55,9 @@
         {% assign num_deadlines = conf.deadline.size %}
         {% assign range_end = conf.deadline.size | minus: 1 %}
         {% for i in (0..range_end) %}
-        {% assign deadline = conf.deadline[i] %}
+        {% assign year = conf.year %}
+        {% assign prevyear = conf.year | minus: 1 %}
+        {% assign deadline = conf.deadline[i] | replace: '%y', year | replace: '%Y', prevyear %}
         {% assign conf_id = conf.name | append: conf.year | append: '-' | append: i | slugify %}
         <div id="{{ conf_id }}" class="conf {% for tag in conf.tags %} {{tag}} {% endfor %}">
           <div class="row">


### PR DESCRIPTION
Related to my previous issue #90 . It would be nice to show all the deadlines of multi-deadline conferences at once and not hide the deadlines that are not the nearest one. use case: 5 days before the deadline you are likely more interested in the next deadline after the nearest one.

Breaking change: we **require** that every `deadline` field in
`conferences.yml` is a real yaml list (e.g., `["2022-..."]` for single
deadlines).

We iterate over every conference and every deadline to create an entry
for every conference/deadline pair. The deadline is identified by the
index into the `deadline` list in the yaml.

some screenshots on what it looks like:
![image](https://user-images.githubusercontent.com/617306/150784408-192ba980-714c-4fed-b839-1bfc899e7cad.png)
![image](https://user-images.githubusercontent.com/617306/150784449-ad7c22e5-3e75-43a0-b76f-13b2c6d1d4f7.png)
