### PR TITLE
fix for sorting in chrome

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -81,40 +81,20 @@ $(function() {
   {% endfor %}
 
   // Reorder list
-  confs = $('.conf');
-  confs.detach().sort(function(a, b) {
-    var today = moment();
-    var a = deadlineByConf[a.id];
-    var b = deadlineByConf[b.id];
-    var diff1 = today.diff(a)
-    var diff2 = today.diff(b)
-    if (a == null && b == null) {
-      return 0;
-    }
-    if (a == null && diff2 > 0) {
+  var today = moment();
+  var confs = $('.conf').detach();
+  confs.sort(function(a, b) {
+    var aDeadline = deadlineByConf[a.id];
+    var bDeadline = deadlineByConf[b.id];
+    var aDiff = today.diff(aDeadline);
+    var bDiff = today.diff(bDeadline);
+    if (aDiff < 0 && bDiff > 0) {
       return -1;
     }
-    if (a == null && diff2 < 0) {
-      return +1;
+    if (aDiff > 0 && bDiff < 0) {
+      return 1;
     }
-    if (b == null && diff1 > 0) {
-      return +1;
-    }
-    if (b == null && diff1 < 0) {
-      return -1;
-    }
-    if (diff1 < 0 && diff2 > 0) {
-      return -1;
-    }
-    if (diff1 > 0 && diff2 < 0) {
-      return +1;
-    }
-    if (diff1 < 0 && diff2 < 0) {
-      return -1 ? diff1 < diff2 : +1;
-    }
-    if (diff1 > 0 && diff2 > 0) {
-      return -1 ? a < b : +1;
-    }
+    return bDiff - aDiff;
   });
   $('.conf-container').append(confs);
 


### PR DESCRIPTION
My Javascript skills aren't that great and I still haven not figured out the bug. Maybe an issue with the `== null` checks? I don't really know why they are there anyway? Shouldn't accessing `a.id` give an error if `a == null`?

Anyway, this change seems to fix the sorting in chrome :shrug: #54 