### PR TITLE
Add SSR 2022

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -153,6 +153,15 @@
   place: Virtual
   tags: [SEC, PRIV, CRYPTO]
 
+- name: SSR
+  description: Security Standardisation Research Conference
+  year: 2022
+  link: https://ssr2022.com/
+  deadline: "2022-03-04 23:59"
+  date: "June 06, 2022"
+  place: Genoa, Italy
+  tags: [SEC, PRIV, CRYPTO]
+
 # Privacy
 
 - name: WPES


### PR DESCRIPTION
Hi!
I suggest adding the (7th) [Security Standardisation Research Conference 2022](https://ssr2022.com). The [CfP](https://ssr2022.com/cfp/) is covering security broadly with a focus on standardisation, incl. crypto and privacy aspects.
Thanks for running this!