### PR TITLE
Add AsianHOST 2022

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -437,3 +437,12 @@
   place: Matsue city, Japan
   tags: [SEC]
   
+- name: AsianHOST
+  description: Asian Hardware Oriented Security and Trust Symposium
+  year: 2022
+  link: http://asianhost.org/2022
+  deadline: ["2022-07-25 23:59"]
+  date: December 15-17 
+  place: Singapore
+  tags: [SEC]
+  

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -443,6 +443,7 @@
   link: http://asianhost.org/2022
   deadline: ["2022-07-25 23:59"]
   date: December 15-17 
+  timezone: Asia/Shanghai
   place: Singapore
   tags: [SEC]
   


### PR DESCRIPTION
2022 Asian Hardware Oriented Security and Trust Symposium
More information can be found here: http://asianhost.org/2022
Thank you!