### PR TITLE
added the IEEE CNS conference

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -458,6 +458,14 @@
   place: Vienna, Austria
   tags: [SEC, PRIV, CRYPTO, SHOP]
 
-  
+  - name: CNS
+  description: IEEE Conference on Communications and Network Security
+  year: 2022
+  link: https://cns2022.ieee-cns.org/
+  deadline: ["2022-05-20 23:59"]
+  timezone: Etc/UTC
+  date: September 26-28
+  place: Austin, TX, USA
+  tags: [SEC, PRIV, CONF]
 
   


### PR DESCRIPTION
added the IEEE CNS conference 2022 (https://cns2022.ieee-cns.org/)