### PR TITLE
SpaceSec23 at NDSS 2023

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -513,3 +513,13 @@
   date: February 27
   place: San Diego, California, USA
   tags: [SEC, PRIV, SHOP]
+
+- name: SpaceSec
+  description: Workshop on the Security of Space and Satellite Systems
+  year: 2023
+  link: https://easychair.org/cfp/SpaceSec23
+  comment: Co-located with NDSS Symposium
+  deadline: ["2023-01-10 23:59"]
+  date: February 27
+  place: San Diego, California, USA
+  tags: [SEC, PRIV, CRYPTO, SHOP]


### PR DESCRIPTION
Added the SpaceSec workshop that is co-located with NDSS Symposium 2023.