### PR TITLE
Rework tag filtering: display only entries matching all tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
         <div class="row">
           <div class="col-xs-12">
             <!-- <div class="well"> -->
+              Select one or more tags to filter (otherwise all deadlines are displayed):
               <form class="form-inline">
                 <div class="form-group">
                   {% for type in site.data.types %}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -107,8 +107,8 @@ $(function() {
     tags = all_tags;
   }
   for (var i = 0; i < tags.length; i++) {
-    $('#' + tags[i] + '-checkbox').prop('checked', true);
-    toggle_status[tags[i]] = true;
+    $('#' + tags[i] + '-checkbox').prop('checked', false);
+    toggle_status[tags[i]] = false;
   }
   store.set('{{ site.domain }}', tags);
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -116,11 +116,17 @@ $(function() {
     confs.each(function(i, conf) {
       var conf = $(conf);
       var show = false;
+      var set_tags = [];
       for (var i = 0; i < all_tags.length; i++) {
-        if(conf.hasClass(all_tags[i])) {
-          show = show | toggle_status[all_tags[i]];
+        // if tag has been selected by user, check if the conference has it
+        if(toggle_status[all_tags[i]]) {
+          set_tags.push(conf.hasClass(all_tags[i]));
         }
       }
+      let empty_or_all_true = arr => arr.every(Boolean);
+      // show a conference if it has all user-selected tags
+      // if no tag is set (= array is empty), show all entries
+      show = empty_or_all_true(set_tags);
       if (show) {
         conf.show();
       } else {


### PR DESCRIPTION
Hi,

currently, the tag system (used for conference filtering) shows an entry if it matches at least one of the selected tags. This isn't particularly helpful in all cases. For example, consider I want to submit a crypto paper to a workshop. Selecting "Crypto" and "Workshop" will show all entries that are either tagged with "Crypto" or "Workshop" -- but I don't really want to see conferences tagged with "Crypto" in this case.

This pull request is a proof of concept (I'm not into JS or anything) of how this behavior could be changed: Only entries that match *all* tags selected by the user are displayed, for example, only entries that are both a "Workshop" and "Crypto".
If no tag is selected, all entries are displayed (no more precise filtering desired). Consequently, I've changed the default behavior when loading the page such that all checkboxes are unchecked.
Beyond the actual code changes, I've also added a line of text above the tags to explain the default behavior.