### PR TITLE
Adding Latincrypt in section Crypto

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -317,6 +317,15 @@
   place: Sousse, Tunisia
   tags: [CRYPTO, CONF]
 
+- name: LATINCRYPT
+  year: 2023
+  description: The 8th International Conference on Cryptology and Information Security in Latin America
+  link: https://www.espe.edu.ec/latincrypt/
+  deadline: ["2023-05-27 23:59"]
+  date:  October 2-6
+  place: Quito, Ecuador
+  tags: [CRYPTO, PRIV, CONF]
+
 - name: CHES
   description: IACR Transactions on Cryptographic Hardware and Embedded Systems
   year: 2023


### PR DESCRIPTION
Conference to be held in Quito Ecuador and is the 8th edition of Latincrypt. Currently hold the status of In Cooperation in the IACR