### PR TITLE
Changed dates for ISC'23

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -201,7 +201,7 @@
   year: 2023
   link: https://isc23.cs.rug.nl
   deadline: ["2023-07-27 23:59"]
-  date: "November 29 - December 1"
+  date: "November 15 - 17"
   place: Groningen, Netherlands
   tags: [SEC, PRIV, CONF]
 


### PR DESCRIPTION
Due to the clash with CCS dates, we changed the dates of the conference.