### PR TITLE
Update Sensors S&P

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -776,6 +776,6 @@
   year: 2023
   date: "November 12"
   link: https://sensorssp.github.io/sensorssp23/
-  deadline: ["2023-09-08 23:59"]
+  deadline: ["2023-09-22 23:59"]
   place: Istanbul, Turkey
   tag: [SEC, PRIV, SHOP]


### PR DESCRIPTION
The deadline was extended to Sept. 22