### PR TITLE
fix: fix #162

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -167,10 +167,10 @@
   year: 2024
   link: https://www.petsymposium.org/cfp24.php
   deadline:
-    - "%Y-05-31 23:59"
-    - "%Y-08-31 23:59"
-    - "%Y-11-30 23:59"
-    - "%y-02-28 23:59"
+    - "2023-05-31 23:59"
+    - "2023-08-31 23:59"
+    - "2023-11-30 23:59"
+    - "2024-02-28 23:59"
   comment: Rolling deadline every quarter
   timezone: Etc/GMT+11
   date: July 15-20


### PR DESCRIPTION
After render the `deadlines.ical` files, the format symbols will remain in the final file, so it can't be import in the Google Calendar nor clients like thunderbird. 