### PR TITLE
Update CCS 2nd deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -19,7 +19,7 @@
   link: https://www.sigsac.org/ccs/CCS2024
   deadline:
     - "2024-01-28 23:59"
-    - "2024-04-14 23:59"
+    - "2024-04-29 23:59"
   date: October 14-18
   place: Salt Lake City, USA
   tags: [SEC, PRIV, CONF]


### PR DESCRIPTION
CCS second review deadline has been postponed to April 29th: https://www.sigsac.org/ccs/CCS2024/call-for/call-for-papers.html