### PR TITLE
Deadline Extension to WoRMA workshop

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -593,7 +593,7 @@
   description: 3rd Workshop on Rethinking Malware Analysis
   year: 2024
   link: https://worma.gitlab.io/2024/
-  deadline: ["2024-03-14 23:59"]
+  deadline: ["2024-03-26 23:59"]
   date: July 8-12
   comment: Co-located with IEEE Euro S&P 2024
   place: Vienna, Austria


### PR DESCRIPTION
Extended the deadline to March 26th AoE: https://worma.gitlab.io/2024/