### PR TITLE
Update the deadline for SecDev 2024

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -553,12 +553,12 @@
   tags: [SEC, PRIV, CONF]
 
 - name: SecDev
-  year: 2023
+  year: 2024
   description: IEEE Secure Development Conference
-  link: https://secdev.ieee.org/2023/home/
-  deadline: ["2023-06-02 23:59"]
-  date: "October 18-20"
-  place: Atlanta, GA, USA
+  link: https://secdev.ieee.org/2024/home
+  deadline: ["2024-05-14 23:59"]
+  date: "October 7-10"
+  place: Pittsburgh, PA, USA
   tags: [SEC, PRIV, CONF]
 
 - name: HOST


### PR DESCRIPTION
Updating the [SecDev 2024](https://secdev.ieee.org/2024/cfp/) deadline and relevant info.