### PR TITLE
Fix deadline for Oakland 2025

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -9,7 +9,7 @@
   link: https://www.ieee-security.org/TC/SP2025
   deadline:
     - "2024-06-06 23:59"
-    - "2024-12-14 23:59"
+    - "2024-11-14 23:59"
   place: San Francisco, California, USA
   tags: [SEC, PRIV, CONF]
 


### PR DESCRIPTION
It is Nov 14, not Dec 14 https://www.ieee-security.org/TC/SP2025/cfpapers.html