### PR TITLE
Add EuroUSEC2024 conference

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -13,6 +13,17 @@
   place: San Francisco, California, USA
   tags: [SEC, PRIV, CONF]
 
+- name: EuroUSEC2024
+  description: The 2024 European Symposium on Usable Security
+  year: 2024
+  link: https://eurousec24.kau.se/
+  deadline: 
+   - "2024-05-27 23:59"
+   - "2024-05-31 23:59"
+  date: September 30-October 1
+  place: Karlstad, Sweden
+  tags: [SEC, PRIV, CONF]
+  
 - name: CCS
   description: ACM Conference on Computer and Communications Security
   year: 2024

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -12,17 +12,6 @@
     - "2024-11-14 23:59"
   place: San Francisco, California, USA
   tags: [SEC, PRIV, CONF]
-
-- name: EuroUSEC2024
-  description: The 2024 European Symposium on Usable Security
-  year: 2024
-  link: https://eurousec24.kau.se/
-  deadline: 
-   - "2024-05-27 23:59"
-   - "2024-05-31 23:59"
-  date: September 30-October 1
-  place: Karlstad, Sweden
-  tags: [SEC, PRIV, CONF]
   
 - name: CCS
   description: ACM Conference on Computer and Communications Security
@@ -119,6 +108,15 @@
   comment: Co-located with USENIX Security. Paper registration due Feb 8 AoE
   date: August 11-13
   place: Philadelphia, PA, USA
+  tags: [SEC, PRIV, CONF]
+
+- name: EuroUSEC
+  description: European Symposium on Usable Security
+  year: 2024
+  link: https://eurousec24.kau.se/
+  deadline: ["2024-05-31 23:59"]
+  date: September 30-October 1
+  place: Karlstad, Sweden
   tags: [SEC, PRIV, CONF]
 
 - name: FC


### PR DESCRIPTION
The website is at [https://eurousec24.kau.se/](https://eurousec24.kau.se/)
The conference has proceedings (will be published in ACM Digital Library)