### PR TITLE
Fix timezone format (GMT instead of UTC)

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -309,7 +309,7 @@
   description: Theory of Cryptography Conference
   year: 2024
   link: https://tcc.iacr.org/2024/
-  timezone: "Etc/UTC-2"
+  timezone: "Etc/GMT-2"
   deadline: ["2024-05-20 20:00"]
   date: "December 2-6"
   place: Milan, Italy
@@ -539,7 +539,7 @@
   year: 2024
   date: "May 27 - 28"
   description: ESA Security for Space Systems Conference
-  timezone: Etc/UTC-2
+  timezone: Etc/GMT-2
   deadline: ["2024-02-08 23:59"]
   link: https://atpi.eventsair.com/24a06---3s2024/
   place: ESTEC, Noordwijk, Netherlands


### PR DESCRIPTION
# The issue
I had put `Etc/UTC-2` as the timezone for TCC.
Noticed both Apple Calendar and Fantastical showed the wrong event times for TCC when importing the ics file. 
- Apple Calendar ignored the timezone specification and (I think) just took the specified time relative to my current timezone. 
- Fantastical seems to have interpreted the specified time as UTC.
- The website showed the correct time.

# The fix
I've traced the issue to the timezone specification, which I had put as `Etc/UTC-2`, but _should_ have put as `Etc/GMT-2` (since the latter style does not seem to run into issues for other conferences).

The commit changes the time zone for TCC and for the one other conference that used a `Etc/UTC±x` specification (to avoid copy/paste errors in the future).