### PR TITLE
Fix PETS time zone

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -213,7 +213,6 @@
     - "%Y-11-30 23:59"
     - "%y-02-28 23:59"
   comment: Rolling deadline every quarter
-  timezone: Etc/GMT+11
   date: July 2025 (TBC)
   place: Washington, DC
   tags: [PRIV, CONF]


### PR DESCRIPTION
The time zone is currently listed as GMT-11, but, [according to the CfP](https://petsymposium.org/cfp25.php), "All deadlines are 23:59:59 Anywhere on Earth (UTC-12)"