### PR TITLE
Extend the deadline of CPSIoTSec

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -636,7 +636,7 @@
   description: The Joint Workshop on CPS & IoT Security and Privacy
   year: 2024
   link: https://cpsiotsec2024.github.io/
-  deadline: ["2024-06-25 23:59"]
+  deadline: ["2024-07-18 23:59"]
   comment: In conjunction with ACM CCS 2024
   date: October 18
   place: Salt Lake City, UT, USA


### PR DESCRIPTION
Extend the deadline of CPSIoTSec till July 18, 2024.