### PR TITLE
Add VehicleSec 2025

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1159,3 +1159,13 @@
   date: August 4-7
   place: Tokyo, Japan
   tags: [SEC, PRIV, SHOP]
+
+- name: VehicleSec
+  description: USENIX Vehicle Security and Privacy
+  year: 2025
+  link: https://x.com/vehiclesec_conf
+  deadline: ["2025-02-27 23:59"]
+  comment: Co-located with USENIX Security 2025
+  date: August 11-12
+  place: Seattle, WA, USA
+  tags: [SEC, PRIV, SHOP]


### PR DESCRIPTION
I would like to add VehicleSec 2025 conference.

VehicleSec is the third symposium on Vehicle Security and Privacy that will be co-located with USENIX Security (one of the big 4 top-tier computer security conferences). 

Thank you!