### PR TITLE
Update conferences.yml

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1092,7 +1092,7 @@
   description: International Workshop on Security
   year: 2025
   link: https://www.iwsec.org/2025/
-  deadline: ["2025-04-03 23:59", "2025-07-17 23:59"]
+  deadline: ["2025-04-10 23:59", "2025-07-17 23:59"]
   timezone: Etc/UTC
   date: November 25-27
   place: Fukuoka, JP


### PR DESCRIPTION
IWSEC 2025: Submission deadline has been extended
April 10, 2025 (AoE) [extended]