### PR TITLE
Extended Deadline for SAFER (ARES Workshop)

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -238,7 +238,7 @@
   description: Workshop on Sustainable security and Awareness For nExt generation infRastructures
   year: 2025
   link: https://2025.ares-conference.eu/program/safer/
-  deadline: ["2025-04-23 23:59"]
+  deadline: ["2025-05-05 23:59"]
   date: August 11-14
   place: Ghent, BE
   tags: [SEC, PRIV, SHOP]


### PR DESCRIPTION
Deadline for [SAFER](https://2025.ares-conference.eu/program/safer/) (ARES Workshop) extended to 5 May