### PR TITLE
Final Deadline Extension for SAFER (ARES 2025 Workshop)

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -228,7 +228,7 @@
   description: Workshop on Sustainable security and Awareness For nExt generation infRastructures
   year: 2025
   link: https://2025.ares-conference.eu/program/safer/
-  deadline: ["2025-05-05 23:59"]
+  deadline: ["2025-05-12 23:59"]
   date: August 11-14
   place: Ghent, BE
   tags: [SEC, PRIV, SHOP]


### PR DESCRIPTION
Final deadline extension to May 12 for SAFER (ARES 2025 Workshop): [Workshop site link](https://2025.ares-conference.eu/program/safer/)