### PR TITLE
Update AISec Workshop 2025

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -801,12 +801,12 @@
   
 - name: AISec
   description: Workshop on Artificial Intelligence and Security
-  year: 2024
+  year: 2025
   link: https://aisec.cc
-  deadline: ["2024-07-07 23:59"]
-  date: October 14-18, 2024
-  comment: Co-located with ACM CCS 2024
-  place: Salt Lake City, UT, USA
+  deadline: ["2025-06-21 23:59"]
+  date: October 17, 2025
+  comment: Co-located with ACM CCS 2025
+  place: Taipei, Taiwan
   tags: [SEC, PRIV, SHOP]
 
 - name: EnergySP


### PR DESCRIPTION
Updated entry for AISec workshop 2025 - co-located with ACM CCS.