### PR TITLE
Eurocrypt 2026

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -349,11 +349,11 @@
 
 - name: Eurocrypt
   description: European Cryptology Conference
-  year: 2025
-  link: https://eurocrypt.iacr.org/2025/
-  deadline: ["2024-10-02 23:59"]
-  date: May 4-8
-  place: Madrid, Spain
+  year: 2026
+  link: https://eurocrypt.iacr.org/2026/
+  deadline: ["2025-10-02 23:59"]
+  date: May 10-14
+  place: Rome, Italy
   tags: [CRYPTO, CONF]
 
 - name: Asiacrypt


### PR DESCRIPTION
Update [Eurocrypt 2026](https://eurocrypt.iacr.org/2026/) to the new year.