### PR TITLE
Add HASP 2025 workshop

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -912,14 +912,13 @@
 
 - name: HASP
   description: Hardware and Architectural Support for Security and Privacy
-  year: 2024
-  link: https://haspworkshop.org/2024/
-  comment: Co-located with MICRO
-  deadline: ["2024-08-15 23:59"]
-  date: November 2
-  timezone: Etc/UTC
-  place: Austin, Texas, United States
-  tags: [SEC, PRIV, SHOP]
+  year: 2025
+  link: https://haspworkshop.org/2025/index.html
+  deadline: ["2025-07-27 23:59"]
+  comment: Co-located with MICRO 2025
+  date: October 18
+  place: Seoul, Korea
+  tags: [SEC, PRIV, SHOP] 
 
 - name: PAVeTrust
   description: Program Analysis and Verification on Trusted Platforms
@@ -1386,13 +1385,3 @@
   date: October 13
   place: Taipei, Taiwan
   tags: [SEC, SHOP]
-
-- name: HASP
-  description: Hardware and Architectural Support for Security and Privacy
-  year: 2025
-  link: https://haspworkshop.org/2025/index.html
-  deadline: ["2025-07-27 23:59"]
-  comment: Co-located with MICRO 2025
-  date: October 18
-  place: Seoul, Korea
-  tags: [SEC, SHOP] 


### PR DESCRIPTION
This pull request adds the HASP 2025 (Hardware and Architectural Support for Security and Privacy) workshop to the list of conferences.

Workshop name: HASP
Description: Hardware and Architectural Support for Security and Privacy
Year: 2025
Link: https://haspworkshop.org/2025/index.html
Submission deadline: July 15, 2025 (23:59 AoE)
Workshop date: October 27, 2025
Place: Chicago, USA
Co-located with MICRO 2025
Tags: [SEC, SHOP]
All information has been taken directly from the official [HASP 2025 website](https://haspworkshop.org/2025/index.html).