### PR TITLE
Add comment about abstract registration to S&P (Oakland) 2026

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -8,6 +8,7 @@
   deadline:
     - "2025-06-05 23:59"
     - "2025-11-13 23:59"
+  comment: Abstract registration required (1 week before deadline AoE).
   place: San Francisco, California, USA
   tags: [SEC, PRIV, CONF, TOP4]
   


### PR DESCRIPTION
According to the [CfP](https://sp2026.ieee-security.org/cfpapers.html) an abstract registration is required.