### PR TITLE
Update WOOT'26 and add four NDSS'26 co-located events

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1002,12 +1002,14 @@
 
 - name: WOOT
   description: USENIX WOOT Conference on Offensive Technologies
-  year: 2025
-  link: https://www.usenix.org/conference/woot25/call-for-papers
-  comment: Co-located with USENIX Security; up-and-coming track deadline is Mar 4
-  deadline: ["2025-03-11 23:59"]
-  date: August 11-12
-  place: Seattle, WA, USA
+  year: 2026
+  link: https://www.usenix.org/conference/woot26/call-for-papers
+  comment: Co-located with USENIX Security; up-and-coming track deadline is Mar 3 (cycle-2)
+  deadline: 
+    - "2025-12-12 23:59"
+    - "2026-03-03 23:59"
+  date: August 10–11
+  place: Baltimore, MD, USA
   tags: [SEC, PRIV, CRYPTO, CONF]
 
 - name: SafeThings


### PR DESCRIPTION
Added new workshops SDIoTSec, WOSOC, LAST-X, and USEC. All of these workshops will be co-located with NDSS'26.