### PR TITLE
Update conferences.yml

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,15 +1,5 @@
 # Security and Privacy
-- name: ACISP
-  description: Australasian Conference on Information Security and Privacy
-  year: 2026
-  link: https://acisp.org/
-  deadline:
-    - "2025-11-27 23:59"
-    - "2026-02-26 23:59"
-  date: July 06-09
-  place: Perth, Australia
-  tags: [SEC, PRIV]
-  
+
 - name: S&P (Oakland)
   year: 2026
   date: May 18-21
@@ -272,6 +262,16 @@
   place: Maribor, Slovenia
   tags: [SEC, SHOP]
 
+- name: ACISP
+  description: Australasian Conference on Information Security and Privacy
+  year: 2026
+  link: https://acisp.org/
+  deadline:
+    - "2025-11-27 23:59"
+    - "2026-02-26 23:59"
+  date: July 6-9
+  place: Perth, Australia
+  tags: [SEC, PRIV, CONF]
 
 - name: ITASEC
   description: Italian Conference on Cybersecurity


### PR DESCRIPTION
31st Australasian Conference on Information Security and Privacy 6 - 9 July 2026, Perth, Australia

- name: ACISP
  description: Australasian Conference on Information Security and Privacy
  year: 2026
  link: https://acisp.org/
  deadline:
    - "2025-11-27 23:59"
    - "2026-02-26 23:59"
  date: July 06-09
  place: Perth, Australia
  tags: [SEC, PRIV]