### PR TITLE
add ACNS-ISC 2026

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -815,6 +815,7 @@
   link: https://acns-isc.github.io/2026/index.html
   deadline: ["2026-03-20 23:59"]
   comment: In conjunction with ACNS 2026
+  date: June 2026
   place: Stony Brook University, NY, USA
   tags: [SEC, SHOP]
 


### PR DESCRIPTION
Added details for the ACNS-ISC 2026 conference including description, year, link, deadline, place, tags.