### PR TITLE
CNS deadline Update

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1061,7 +1061,7 @@
   description: IEEE Conference on Communications and Network Security
   year: 2026
   link: https://cns2026.ieee-cns.org/
-  deadline: ["2026-05-11 23:59"]
+  deadline: ["2026-05-18 23:59"]
   date: September 14 - 17
   place: Newark, DE, USA
   tags: [SEC, PRIV, CONF]


### PR DESCRIPTION
The CNS deadline is extended by a week. 

Ref: [Link](https://cns2026.ieee-cns.org/authors)