### PR TITLE
Adding CFP for TAKEDOWN

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2037,3 +2037,12 @@
   date: December 7-11
   place: Sendai, Japan
   tags: [SEC, PRIV, SHOP, OTHERS]
+
+- name: TAKEDOWN
+  description: ACM Technical Analysis and Knowledge Exchange on Disrupting Online Criminal Networks
+  year: 2026
+  link: https://takedown-workshop.com/
+  deadline: ["2026-07-13 23:59"]
+  date: December 7-11
+  place: The Hague, The Netherlands
+  tags: [SEC, SHOP, OTHERS]

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2046,3 +2046,4 @@
   date: December 7-11
   place: The Hague, The Netherlands
   tags: [SEC, SHOP, OTHERS]
+  comment: Co-located with CCS 2026


### PR DESCRIPTION
A workshop of CCS 2026
Full title: Technical Analysis and Knowledge Exchange on Disrupting Online Criminal Networks

