### PR TITLE
Added RASE 2026 (ASE 2026 workshop)

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2065,4 +2065,4 @@
   deadline: ["2026-07-24 23:59"]
   date: October 12-16
   place: Munich, Germany
-  tags: [SEC, SHOP]
+  tags: [SEC, SHOP, OTHERS]

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -2056,3 +2056,13 @@
   place: The Hague, The Netherlands
   tags: [SEC, SHOP, OTHERS]
   comment: Co-located with CCS 2026
+
+- name: RASE
+  description: Workshop on Reliable and trustworthy Automated Software Engineering
+  year: 2026
+  link: https://conf.researchr.org/home/ase-2026/rase-2026
+  comment: Co-located with ASE 2026
+  deadline: ["2026-07-24 23:59"]
+  date: October 12-16
+  place: Munich, Germany
+  tags: [SEC, SHOP]


### PR DESCRIPTION
Added 1st Workshop on Reliable and trustworthy Automated Software Engineering (RASE) 2026, co-located with the 41st IEEE/ACM International Conference on Automated Software Engineering (ASE 2026).

While the main conference is focused on Software Engineering, our workshop cover topics at the intersection of software security and software engineering (e.g. automated vulnerability detection, localization, and repair; protection of software assets), thus we believe it could be of interest to the cybersecurity community.