### PR TITLE
Extend CANS'2026 deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -104,7 +104,7 @@
   year: 2026
   link: https://uow-ic2.github.io/cans2026/index.html
   dblp: https://dblp.org/db/conf/cans/index.html
-  deadline: ["2026-06-10 23:59"]
+  deadline: ["2026-06-19 23:59"]
   date: November 23-25
   place: Wollongong, Australia
   tags: [SEC, CRYPTO, CONF, CORE-B]


### PR DESCRIPTION
Extend CANS'2026 deadline to 19/June