### PR TITLE
Update RISC 2026, Add TPS-ISA 2026

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -871,12 +871,23 @@
   place: Montreal, Canada
   tags: [SEC, PRIV, CONF, OTHERS]
 
+- name: TPS-ISA
+  year: 2026
+  description: IEEE International Conference on Trust, Privacy and Security in Intelligent Systems, and Applications
+  link: https://tps.ieee-cs.org/2026/call-for-papers/
+  deadline:
+    - "2026-06-15 23:59"
+    - "2026-08-15 23:59"
+  date: "November 4-6"
+  place: San Jose, CA, USA
+  tags: [SEC, PRIV, CONF, OTHERS]
+
 - name: RISC
   year: 2026
   description: IEEE International Conference on Resilience and Integrated Security for Space and Critical Systems
-  link: https://www.sis.pitt.edu/lersais/conference/risc/2026/call-for-papers/
+  link: https://risc.ieee-cs.org/2026/call-for-papers/
   deadline:
-    - "2026-06-01 23:59"
+    - "2026-06-15 23:59"
     - "2026-08-15 23:59"
   date: "November 4-6"
   place: San Jose, CA, USA


### PR DESCRIPTION
This commit changes 3 things in conferences.yml

- Changed the Call for Papers page for IEEE RISC 2026 from https://www.sis.pitt.edu/lersais/conference/risc/2026/call-for-papers/ (old) to https://risc.ieee-cs.org/2026/call-for-papers/ (new), as indicated by the site
- Extended the Round 1 submission deadline for IEEE RISC 2026 to Jun. 15
- Added IEEE TPS 2026: https://tps.ieee-cs.org/2026/call-for-papers/

Feel free to contact me (liou.tang@pitt.edu) as the web co-chair for both conferences.