### PR TITLE
Update DSN 2027 deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -466,13 +466,13 @@
 
 - name: DSN
   description: The International Conference on Dependable Systems and Networks
-  year: 2026
+  year: 2027
   link: https://dsn2026.github.io/
   dblp: https://dblp.org/db/conf/dsn/index.html
-  deadline: ["2025-12-04 23:59"]
+  deadline: ["2026-12-02 23:59"]
   comment: Abstract registration required (1 week before deadline AoE).
   date: June 22-25
-  place: Charlotte, NC, USA
+  place: Berlin, Germany
   tags: [SEC, CONF, CORE-A]
 
 - name: ACNS

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -467,7 +467,7 @@
 - name: DSN
   description: The International Conference on Dependable Systems and Networks
   year: 2027
-  link: https://dsn2026.github.io/
+  link: https://dsn2027-berlin.github.io/
   dblp: https://dblp.org/db/conf/dsn/index.html
   deadline: ["2026-12-02 23:59"]
   comment: Abstract registration required (1 week before deadline AoE).


### PR DESCRIPTION
Updates the DSN entry in `_data/conferences.yml` with the latest conference information.

Changes include:
  
    * Updated year
    * Updated conference website link
    * Updated submission deadline
    * Updated conference date and location

Source: https://dsn2027-berlin.github.io/
