### PR TITLE
Update deadline for PKC 2027 conference

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -332,7 +332,7 @@
   year: 2027
   link: https://pkc.iacr.org/2027/
   dblp: https://dblp.org/db/conf/pkc/index.html
-  deadline: ["2026-08-03 23:59"]
+  deadline: ["2026-08-16 23:59"]
   date: March 1-4
   place: Taipei, Taiwan
   tags: [CRYPTO, CONF, CORE-B]


### PR DESCRIPTION
This PR updates the PKC 2027 submission deadline from August 3
to August 16, 2026, according to the official Call for Papers.

Official source:
https://pkc.iacr.org/2027/callforpapers.php