### PR TITLE
Fix conference deadline records

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -728,8 +728,8 @@
   description: ACM SIGSOFT International Symposium on Software Testing and Analysis
   year: 2027
   link: https://conf.researchr.org/home/issta-2027
-  deadline: ["2026-01-11 23:59"]
-  comment: Abstract registration deadline January 8 (AoE).
+  deadline: ["2027-01-11 23:59"]
+  comment: Mandatory abstract submission deadline January 8, 2027 (AoE).
   date: September 7 - 10
   place: Singapore
   tags: [SEC, CONF, CORE-A]

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1754,10 +1754,10 @@
 
 - name: ACSW
   description: Workshop on Automotive Cyber-Security
-  year: 2025
+  year: 2026
   comment: Co-Located with IEEE European Symposium on Security and Privacy
   link: https://acsw.unimore.it/
-  deadline: ["2026-3-12 23:59"]
+  deadline: ["2026-03-19 23:59"]
   date: July 10
   place: Lisbon, Portugal
   tags: [SEC, PRIV, SHOP, OTHERS]

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -76,11 +76,10 @@
 
 - name: Euro S&P
   description: IEEE European Symposium on Security and Privacy
-  year: 2026
-  comment: Abstract registration required (1 week before deadline AoE).
-  link: https://eurosp2026.ieee-security.org/
+  year: 2027
+  link: https://eurosp2027.ieee-security.org/
   dblp: https://dblp.org/db/conf/eurosp/index.html
-  deadline: ["2025-11-20 23:59"]
+  deadline: ["2026-11-20 23:59"]
   date: "July 6 - 10"
   place: Lisbon, Portugal
   tags: [SEC, PRIV, CONF, CORE-A]

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -76,10 +76,11 @@
 
 - name: Euro S&P
   description: IEEE European Symposium on Security and Privacy
-  year: 2027
-  link: https://eurosp2027.ieee-security.org/
+  year: 2026
+  comment: Abstract registration required (1 week before deadline AoE).
+  link: https://eurosp2026.ieee-security.org/
   dblp: https://dblp.org/db/conf/eurosp/index.html
-  deadline: ["2026-11-20 23:59"]
+  deadline: ["2025-11-20 23:59"]
   date: "July 6 - 10"
   place: Lisbon, Portugal
   tags: [SEC, PRIV, CONF, CORE-A]


### PR DESCRIPTION
## Changes

- Correct the ISSTA 2027 paper deadline year and use the official term for its mandatory abstract deadline.
- Move Euro S&P to its 2027 edition using dates published by IEEE. The 2027 homepage currently says "Coming soon"; the IEEE CFP notice and Cipher calendar confirm the URL, submission deadline, conference dates, and location.
- Correct ACSW to the 2026 edition and record its firm extended paper deadline.

## Why

The ISSTA deadline used the wrong year. The Euro S&P record still described the previous edition, and the ACSW record combined a stale edition year with an older deadline. These corrections keep the displayed countdowns tied to the published conference information.

## Sources

- [ISSTA 2027 research papers](https://conf.researchr.org/track/issta-2027/issta-2027-research-papers)
- [IEEE Euro S&P 2027 CFP notice](https://www.ieee-security.org/Calendar/cfps/cfp-EuroSnP2027.html)
- [IEEE Cipher calendar](https://www.ieee-security.org/Calendar/cipher-hypercalendar.html)
- [ACSW 2026 call for papers](https://acsw.unimore.it/)
