### PR TITLE
DFC Europe

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -74,6 +74,17 @@
   place: Macau
   tags: [SEC, PRIV, CONF, CORE-A]
 
+- name: DFC Europe
+  description: Digital Forensics Conference Europe
+  year: 2027
+  link: https://dfrws.org/conferences/dfceurope2027/
+  dblp: https://dblp.org/db/conf/dfrws/index.html
+  deadline: ["2026-09-25 23:59"]
+  comment: Abstract and title registration required by September 18, 2026 (AoE).
+  date: March 30-April 2
+  place: Edinburgh, Scotland
+  tags: [SEC, CONF, OTHERS]
+
 - name: Euro S&P
   description: IEEE European Symposium on Security and Privacy
   year: 2026

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,15 @@
 # Security and Privacy
+- name: DFC Europe
+  description: Digital Forensics Conference Europe
+  year: 2027
+  link: https://dfrws.org/conferences/dfceurope2027/
+  dblp: https://dblp.org/db/conf/dfrws/index.html
+  deadline: ["2026-09-25 23:59"]
+  comment: Abstract and title registration required by September 18, 2026 (AoE).
+  date: March 30-April 2
+  place: Edinburgh, Scotland
+  tags: [SEC, CONF, OTHERS]
+  
 - name: S&P (Oakland)
   year: 2027
   date: TBA
@@ -73,17 +84,6 @@
   date: "July 12-16"
   place: Macau
   tags: [SEC, PRIV, CONF, CORE-A]
-
-- name: DFC Europe
-  description: Digital Forensics Conference Europe
-  year: 2027
-  link: https://dfrws.org/conferences/dfceurope2027/
-  dblp: https://dblp.org/db/conf/dfrws/index.html
-  deadline: ["2026-09-25 23:59"]
-  comment: Abstract and title registration required by September 18, 2026 (AoE).
-  date: March 30-April 2
-  place: Edinburgh, Scotland
-  tags: [SEC, CONF, OTHERS]
 
 - name: Euro S&P
   description: IEEE European Symposium on Security and Privacy

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,15 +1,4 @@
 # Security and Privacy
-- name: DFC Europe
-  description: Digital Forensics Conference Europe
-  year: 2027
-  link: https://dfrws.org/conferences/dfceurope2027/
-  dblp: https://dblp.org/db/conf/dfrws/index.html
-  deadline: ["2026-09-25 23:59"]
-  comment: Abstract and title registration required by September 18, 2026 (AoE).
-  date: March 30-April 2
-  place: Edinburgh, Scotland
-  tags: [SEC, CONF, OTHERS]
-  
 - name: S&P (Oakland)
   year: 2027
   date: TBA
@@ -193,6 +182,17 @@
   date: October 9-11
   place: Gothenburg, Sweden
   tags: [SEC, CONF, CORE-C]
+
+- name: DFC Europe
+  description: Digital Forensics Conference Europe
+  year: 2027
+  link: https://dfrws.org/conferences/dfceurope2027/
+  dblp: https://dblp.org/db/conf/dfrws/index.html
+  deadline: ["2026-09-25 23:59"]
+  comment: Abstract and title registration required by September 18, 2026 (AoE).
+  date: March 30-April 2
+  place: Edinburgh, Scotland
+  tags: [SEC, CONF, OTHERS]
 
 # Privacy
 


### PR DESCRIPTION
- name: DFC Europe
  description: Digital Forensics Conference Europe
  year: 2027
  link: https://dfrws.org/conferences/dfceurope2027/
  dblp: https://dblp.org/db/conf/dfrws/index.html
  deadline: ["2026-09-25 23:59"]
  comment: Abstract and title registration required by September 18, 2026 (AoE).
  date: March 30-April 2
  place: Edinburgh, Scotland
  tags: [SEC, CONF, OTHERS]