### PR TITLE
Update TPS-ISA and RISC 2026

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -895,9 +895,10 @@
   year: 2026
   description: IEEE International Conference on Trust, Privacy and Security in Intelligent Systems, and Applications
   link: https://tps.ieee-cs.org/2026/call-for-papers/
+  dblp: https://dblp.org/db/conf/tpsisa/index.html
   deadline:
     - "2026-06-15 23:59"
-    - "2026-08-15 23:59"
+    - "2026-08-22 23:59"
   date: "November 4-6"
   place: San Jose, CA, USA
   tags: [SEC, PRIV, CONF, OTHERS]
@@ -908,7 +909,7 @@
   link: https://risc.ieee-cs.org/2026/call-for-papers/
   deadline:
     - "2026-06-15 23:59"
-    - "2026-08-15 23:59"
+    - "2026-08-22 23:59"
   date: "November 4-6"
   place: San Jose, CA, USA
   tags: [SEC, CONF, OTHERS]


### PR DESCRIPTION
This commit changes 3 things in conferences.yml:

* Extended the Round 2 submission deadline for TPS-ISA 2026 and RISC 2026 to Aug. 22, 2026, see: https://tps.ieee-cs.org/2026/call-for-papers/ and https://risc.ieee-cs.org/2026/call-for-papers/
* Added the dblp link to TPS-ISA: https://dblp.org/db/conf/tpsisa/index.html

Feel free to contact me ([liou.tang@pitt.edu](mailto:liou.tang@pitt.edu)) as the web co-chair for both conferences.
